### PR TITLE
Slight accessibility improvements for date picker table cells

### DIFF
--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -32,8 +32,10 @@ module DateTimePicker
 -}
 
 import Date exposing (Date)
+import Date.Extra.Config.Config_en_us
 import Date.Extra.Core
 import Date.Extra.Duration
+import Date.Extra.Format
 import DateTimePicker.AnalogClock
 import DateTimePicker.ClockUtils
 import DateTimePicker.Config exposing (Config, DatePickerConfig, TimePickerConfig, TimePickerType(..), Type(..), defaultDatePickerConfig, defaultDateTimePickerConfig, defaultTimePickerConfig)
@@ -811,6 +813,10 @@ calendar pickerType state currentDate =
                                 |> Maybe.withDefault False
 
                         toCell day =
+                            let
+                                selectedDate =
+                                    DateTimePicker.DateUtils.toDate year month day
+                            in
                             td
                                 [ class
                                     (case day.monthType of
@@ -831,6 +837,7 @@ calendar pickerType state currentDate =
                                             [ NextMonth ]
                                     )
                                 , Html.Attributes.attribute "role" "button"
+                                , Html.Attributes.attribute "aria-label" (Date.Extra.Format.format Date.Extra.Config.Config_en_us.config "%e, %A %B %Y" selectedDate)
                                 , onMouseDownPreventDefault <| dateClickHandler pickerType stateValue year month day
                                 , onTouchStartPreventDefault <| dateClickHandler pickerType stateValue year month day
                                 ]

--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -830,6 +830,7 @@ calendar pickerType state currentDate =
                                         DateTimePicker.DateUtils.Next ->
                                             [ NextMonth ]
                                     )
+                                , Html.Attributes.attribute "role" "button"
                                 , onMouseDownPreventDefault <| dateClickHandler pickerType stateValue year month day
                                 , onTouchStartPreventDefault <| dateClickHandler pickerType stateValue year month day
                                 ]

--- a/tests/AccessibilityTests.elm
+++ b/tests/AccessibilityTests.elm
@@ -1,0 +1,60 @@
+module AccessibilityTests exposing (..)
+
+import Date exposing (Date)
+import DateTimePicker
+import Html.Attributes
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (..)
+
+
+now : Date
+now =
+    -- 2017-08-11T22:30:55Z
+    Date.fromTime 1502490656000
+
+
+open : DateTimePicker.State -> DateTimePicker.State
+open oldState =
+    DateTimePicker.datePicker
+        (,)
+        []
+        oldState
+        Nothing
+        |> Query.fromHtml
+        |> Query.find [ tag "input" ]
+        |> Event.simulate Event.focus
+        |> Event.toResult
+        |> (\result ->
+                case result of
+                    Err message ->
+                        Debug.crash ("Can't open datetimepicker:" ++ message)
+
+                    Ok ( state, date ) ->
+                        state
+           )
+
+
+render : DateTimePicker.State -> Query.Single ()
+render state =
+    DateTimePicker.datePicker
+        (\_ _ -> ())
+        []
+        state
+        Nothing
+        |> Query.fromHtml
+
+
+datePickerTests : Test
+datePickerTests =
+    describe "date picker accessibility"
+        [ test "date cells should have role=button" <|
+            \() ->
+                DateTimePicker.initialStateWithToday now
+                    |> open
+                    |> render
+                    |> Query.findAll [ tag "td" ]
+                    |> Query.each
+                        (Query.has [ attribute <| Html.Attributes.attribute "role" "button" ])
+        ]

--- a/tests/AccessibilityTests.elm
+++ b/tests/AccessibilityTests.elm
@@ -56,5 +56,16 @@ datePickerTests =
                     |> render
                     |> Query.findAll [ tag "td" ]
                     |> Query.each
-                        (Query.has [ attribute <| Html.Attributes.attribute "role" "button" ])
+                        (Query.has [ attribute "role" "button" ])
+        , test "date cells should have labels" <|
+            \() ->
+                DateTimePicker.initialStateWithToday now
+                    |> open
+                    |> render
+                    |> Query.has [ tag "td", attribute "aria-label" "15, Tuesday August 2017" ]
         ]
+
+
+attribute : String -> String -> Selector
+attribute attr value =
+    Test.Html.Selector.attribute <| Html.Attributes.attribute attr value

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,10 +9,13 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "abadi199/dateparser": "1.0.0 <= v < 2.0.0",
+        "eeue56/elm-html-test": "5.0.1 <= v < 6.0.0",
         "elm-community/elm-test": "4.1.1 <= v < 5.0.0",
         "elm-community/list-extra": "4.0.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/svg": "2.0.0 <= v < 3.0.0",
         "rluiten/elm-date-extra": "8.1.2 <= v < 9.0.0",
         "rtfeldman/elm-css": "7.0.0 <= v < 8.0.0",
         "rtfeldman/elm-css-helpers": "2.0.1 <= v < 3.0.0"


### PR DESCRIPTION
(Related to https://github.com/abadi199/datetimepicker/issues/2)

Following the example of http://whatsock.com/tsg/Coding%20Arena/ARIA%20Date%20Pickers/ARIA%20Date%20Picker%20(Basic)/demo.htm, this makes a few small accessibility improvements:

  - Add role=button to the date picker cells
  - Add aria labels to the date picker cells to clarify the exact date that clicking it will choose

This also makes it easier to select dates via the date picker in automated tests.

A future change that should still be made is: add keyboard navigation among the cells, and have the selected cell be tabindex=0 and other cells be tabindex=-1.

Future improvements:  what configuration should be allowed here?  I think we should not allow configuration of the label format, but we do need to allow the month/day-of-the-week language to be configured.