### PR TITLE
Refactoring (prep for fixing timezone handling)

### DIFF
--- a/src/DatePickerPanel.elm
+++ b/src/DatePickerPanel.elm
@@ -1,0 +1,348 @@
+module DatePickerPanel exposing (Config, view)
+
+import Date exposing (Date)
+import Date.Extra.Config.Config_en_us
+import Date.Extra.Core
+import Date.Extra.Duration
+import Date.Extra.Format
+import DateTimePicker.Config exposing (Config, DatePickerConfig, NameOfDays, TimePickerConfig, TimePickerType(..), Type(..), defaultDatePickerConfig, defaultDateTimePickerConfig, defaultTimePickerConfig)
+import DateTimePicker.DateUtils
+import DateTimePicker.Events exposing (onBlurWithChange, onMouseDownPreventDefault, onMouseUpPreventDefault, onTouchEndPreventDefault, onTouchStartPreventDefault)
+import DateTimePicker.Internal exposing (InternalState(..), StateValue, Time, getStateValue, initialStateValue, initialStateValueWithToday)
+import DateTimePicker.SharedStyles exposing (CssClasses(..), datepickerNamespace)
+import DateTimePicker.Svg
+import Html exposing (..)
+import Html.Attributes exposing (value)
+import List.Extra
+
+
+type alias State =
+    InternalState
+
+
+type alias Config msg =
+    { onChange : State -> Maybe Date -> msg
+    , nameOfDays : NameOfDays
+    , firstDayOfWeek : Date.Day
+    , allowYearNavigation : Bool
+    , titleFormatter : Date -> String
+    , footerFormatter : Date -> String
+    , requiresTime : Bool
+    }
+
+
+
+-- ACTIONS
+
+
+switchMode : State -> State
+switchMode (InternalState state) =
+    InternalState { state | event = "title" }
+
+
+gotoNextMonth : State -> State
+gotoNextMonth (InternalState state) =
+    let
+        updatedTitleDate =
+            Maybe.map (Date.Extra.Duration.add Date.Extra.Duration.Month 1) state.titleDate
+    in
+    InternalState
+        { state
+            | event = "next"
+            , titleDate = updatedTitleDate
+        }
+
+
+gotoNextYear : State -> State
+gotoNextYear (InternalState state) =
+    let
+        updatedTitleDate =
+            Maybe.map (Date.Extra.Duration.add Date.Extra.Duration.Year 1) state.titleDate
+    in
+    InternalState
+        { state
+            | event = "nextYear"
+            , titleDate = updatedTitleDate
+        }
+
+
+gotoPreviousMonth : State -> State
+gotoPreviousMonth (InternalState state) =
+    let
+        updatedTitleDate =
+            Maybe.map (Date.Extra.Duration.add Date.Extra.Duration.Month -1) state.titleDate
+    in
+    InternalState
+        { state
+            | event = "previous"
+            , titleDate = updatedTitleDate
+        }
+
+
+gotoPreviousYear : State -> State
+gotoPreviousYear (InternalState state) =
+    let
+        updatedTitleDate =
+            Maybe.map (Date.Extra.Duration.add Date.Extra.Duration.Year -1) state.titleDate
+    in
+    InternalState
+        { state
+            | event = "previousYear"
+            , titleDate = updatedTitleDate
+        }
+
+
+
+-- VIEWS
+
+
+{ id, class, classList } =
+    datepickerNamespace
+
+
+view : Config msg -> State -> Maybe Date -> Html msg
+view config ((InternalState stateValue) as state) currentDate =
+    div [ class [ DatePickerDialog ] ]
+        [ div [ class [ Header ] ]
+            (navigation config state currentDate)
+        , calendar config state currentDate
+        , div
+            [ class [ Footer ] ]
+            [ stateValue.date |> Maybe.map config.footerFormatter |> Maybe.withDefault "--" |> text ]
+        ]
+
+
+navigation : Config msg -> State -> Maybe Date.Date -> List (Html msg)
+navigation config state currentDate =
+    [ previousYearButton config state currentDate
+    , previousButton config state currentDate
+    , title config state currentDate
+    , nextButton config state currentDate
+    , nextYearButton config state currentDate
+    ]
+
+
+title : Config msg -> State -> Maybe Date.Date -> Html msg
+title config ((InternalState stateValue) as state) currentDate =
+    let
+        date =
+            stateValue.titleDate
+    in
+    span
+        [ class [ Title ]
+        , onMouseDownPreventDefault <| config.onChange (switchMode state) currentDate
+        ]
+        [ date
+            |> Maybe.map config.titleFormatter
+            |> Maybe.withDefault "N/A"
+            |> text
+        ]
+
+
+previousYearButton : Config msg -> State -> Maybe Date.Date -> Html msg
+previousYearButton config state currentDate =
+    if config.allowYearNavigation then
+        span
+            [ class [ DoubleArrowLeft ]
+            , onMouseDownPreventDefault <| config.onChange (gotoPreviousYear state) currentDate
+            , onTouchStartPreventDefault <| config.onChange (gotoPreviousYear state) currentDate
+            ]
+            [ DateTimePicker.Svg.doubleLeftArrow ]
+    else
+        Html.text ""
+
+
+noYearNavigationClass : Config msg -> List CssClasses
+noYearNavigationClass config =
+    if config.allowYearNavigation then
+        []
+    else
+        [ NoYearNavigation ]
+
+
+previousButton : Config msg -> State -> Maybe Date.Date -> Html msg
+previousButton config state currentDate =
+    span
+        [ class <| ArrowLeft :: noYearNavigationClass config
+        , onMouseDownPreventDefault <| config.onChange (gotoPreviousMonth state) currentDate
+        , onTouchStartPreventDefault <| config.onChange (gotoPreviousMonth state) currentDate
+        ]
+        [ DateTimePicker.Svg.leftArrow ]
+
+
+nextButton : Config msg -> State -> Maybe Date.Date -> Html msg
+nextButton config state currentDate =
+    span
+        [ class <| ArrowRight :: noYearNavigationClass config
+        , onMouseDownPreventDefault <| config.onChange (gotoNextMonth state) currentDate
+        , onTouchStartPreventDefault <| config.onChange (gotoNextMonth state) currentDate
+        ]
+        [ DateTimePicker.Svg.rightArrow ]
+
+
+nextYearButton : Config msg -> State -> Maybe Date.Date -> Html msg
+nextYearButton config state currentDate =
+    if config.allowYearNavigation then
+        span
+            [ class [ DoubleArrowRight ]
+            , onMouseDownPreventDefault <| config.onChange (gotoNextYear state) currentDate
+            , onTouchStartPreventDefault <| config.onChange (gotoNextYear state) currentDate
+            ]
+            [ DateTimePicker.Svg.doubleRightArrow ]
+    else
+        Html.text ""
+
+
+calendar : Config msg -> State -> Maybe Date.Date -> Html msg
+calendar config (InternalState state) currentDate =
+    case state.titleDate of
+        Nothing ->
+            Html.text ""
+
+        Just titleDate ->
+            let
+                firstDay =
+                    Date.Extra.Core.toFirstOfMonth titleDate
+                        |> Date.dayOfWeek
+                        |> DateTimePicker.DateUtils.dayToInt config.firstDayOfWeek
+
+                month =
+                    Date.month titleDate
+
+                year =
+                    Date.year titleDate
+
+                days =
+                    DateTimePicker.DateUtils.generateCalendar config.firstDayOfWeek month year
+
+                header =
+                    thead [ class [ DaysOfWeek ] ]
+                        [ tr
+                            []
+                            (dayNames config)
+                        ]
+
+                isHighlighted day =
+                    state.date
+                        |> Maybe.map (\current -> day.day == Date.day current && month == Date.month current && year == Date.year current)
+                        |> Maybe.withDefault False
+
+                isToday day =
+                    state.today
+                        |> Maybe.map (\today -> day.day == Date.day today && month == Date.month today && year == Date.year today)
+                        |> Maybe.withDefault False
+
+                toCell day =
+                    let
+                        selectedDate =
+                            DateTimePicker.DateUtils.toDate year month day
+                    in
+                    td
+                        [ class
+                            (case day.monthType of
+                                DateTimePicker.DateUtils.Previous ->
+                                    [ PreviousMonth ]
+
+                                DateTimePicker.DateUtils.Current ->
+                                    CurrentMonth
+                                        :: (if isHighlighted day then
+                                                [ SelectedDate ]
+                                            else if isToday day then
+                                                [ Today ]
+                                            else
+                                                []
+                                           )
+
+                                DateTimePicker.DateUtils.Next ->
+                                    [ NextMonth ]
+                            )
+                        , Html.Attributes.attribute "role" "button"
+                        , Html.Attributes.attribute "aria-label" (Date.Extra.Format.format Date.Extra.Config.Config_en_us.config "%e, %A %B %Y" selectedDate)
+                        , onMouseDownPreventDefault <| dateClickHandler config state year month day
+                        , onTouchStartPreventDefault <| dateClickHandler config state year month day
+                        ]
+                        [ text <| toString day.day ]
+
+                toWeekRow week =
+                    tr [] (List.map toCell week)
+
+                body =
+                    tbody [ class [ Days ] ]
+                        (days
+                            |> List.Extra.groupsOf 7
+                            |> List.map toWeekRow
+                        )
+            in
+            table [ class [ Calendar ] ]
+                [ header
+                , body
+                ]
+
+
+dayNames : Config msg -> List (Html msg)
+dayNames config =
+    let
+        days =
+            [ th [] [ text config.nameOfDays.sunday ]
+            , th [] [ text config.nameOfDays.monday ]
+            , th [] [ text config.nameOfDays.tuesday ]
+            , th [] [ text config.nameOfDays.wednesday ]
+            , th [] [ text config.nameOfDays.thursday ]
+            , th [] [ text config.nameOfDays.friday ]
+            , th [] [ text config.nameOfDays.saturday ]
+            ]
+
+        shiftAmount =
+            DateTimePicker.DateUtils.dayToInt Date.Sun config.firstDayOfWeek
+    in
+    days
+        |> List.Extra.splitAt shiftAmount
+        |> (\( head, tail ) -> tail ++ head)
+
+
+dateClickHandler : Config msg -> StateValue -> Int -> Date.Month -> DateTimePicker.DateUtils.Day -> msg
+dateClickHandler config state year month day =
+    let
+        selectedDate =
+            DateTimePicker.DateUtils.toDate year month day
+
+        updatedState =
+            InternalState
+                { state
+                    | date = Just <| selectedDate
+                    , forceClose = forceClose
+                    , activeTimeIndicator =
+                        if state.time.hour == Nothing then
+                            Just DateTimePicker.Internal.HourIndicator
+                        else if state.time.minute == Nothing then
+                            Just DateTimePicker.Internal.MinuteIndicator
+                        else if state.time.amPm == Nothing then
+                            Just DateTimePicker.Internal.AMPMIndicator
+                        else
+                            Nothing
+                }
+
+        ( updatedDate, forceClose ) =
+            case ( config.requiresTime, state.time.hour, state.time.minute, state.time.amPm ) of
+                ( True, Just hour, Just minute, Just amPm ) ->
+                    ( Just <| DateTimePicker.DateUtils.setTime selectedDate hour minute amPm
+                    , True
+                    )
+
+                ( False, _, _, _ ) ->
+                    ( Just selectedDate
+                    , True
+                    )
+
+                _ ->
+                    ( Nothing, False )
+    in
+    case day.monthType of
+        DateTimePicker.DateUtils.Previous ->
+            config.onChange (gotoPreviousMonth updatedState) updatedDate
+
+        DateTimePicker.DateUtils.Next ->
+            config.onChange (gotoNextMonth updatedState) updatedDate
+
+        DateTimePicker.DateUtils.Current ->
+            config.onChange updatedState updatedDate

--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -41,7 +41,7 @@ module DateTimePicker
 
 -}
 
-import Date exposing (Date)
+import Date
 import Date.Extra.Config.Config_en_us
 import Date.Extra.Core
 import Date.Extra.Duration
@@ -90,7 +90,7 @@ initialStateWithToday today =
 
 {-| Initial Cmd to set the initial month to be displayed in the datepicker to the current month.
 -}
-initialCmd : (State -> Maybe Date -> msg) -> State -> Cmd msg
+initialCmd : (State -> Maybe Date.Date -> msg) -> State -> Cmd msg
 initialCmd onChange state =
     let
         stateValue =
@@ -112,7 +112,7 @@ initialCmd onChange state =
 -- ACTIONS
 
 
-switchMode : Config a msg -> State -> (Maybe Date -> msg)
+switchMode : Config a msg -> State -> (Maybe Date.Date -> msg)
 switchMode config state =
     let
         stateValue =
@@ -121,7 +121,7 @@ switchMode config state =
     config.onChange <| InternalState { stateValue | event = "title" }
 
 
-gotoNextMonth : Config a msg -> State -> (Maybe Date -> msg)
+gotoNextMonth : Config a msg -> State -> (Maybe Date.Date -> msg)
 gotoNextMonth config state =
     let
         stateValue =
@@ -133,7 +133,7 @@ gotoNextMonth config state =
     config.onChange <| InternalState { stateValue | event = "next", titleDate = updatedTitleDate }
 
 
-gotoNextYear : Config a msg -> State -> (Maybe Date -> msg)
+gotoNextYear : Config a msg -> State -> (Maybe Date.Date -> msg)
 gotoNextYear config state =
     let
         stateValue =
@@ -145,7 +145,7 @@ gotoNextYear config state =
     config.onChange <| InternalState { stateValue | event = "nextYear", titleDate = updatedTitleDate }
 
 
-gotoPreviousMonth : Config a msg -> State -> (Maybe Date -> msg)
+gotoPreviousMonth : Config a msg -> State -> (Maybe Date.Date -> msg)
 gotoPreviousMonth config state =
     let
         stateValue =
@@ -157,7 +157,7 @@ gotoPreviousMonth config state =
     config.onChange <| InternalState { stateValue | event = "previous", titleDate = updatedTitleDate }
 
 
-gotoPreviousYear : Config a msg -> State -> (Maybe Date -> msg)
+gotoPreviousYear : Config a msg -> State -> (Maybe Date.Date -> msg)
 gotoPreviousYear config state =
     let
         stateValue =
@@ -193,7 +193,7 @@ type alias Model = { datePickerState : DateTimePicker.State, value : Maybe Date 
             model.value
 
 -}
-datePicker : (State -> Maybe Date -> msg) -> List (Html.Attribute msg) -> State -> Maybe Date -> Html msg
+datePicker : (State -> Maybe Date.Date -> msg) -> List (Html.Attribute msg) -> State -> Maybe Date.Date -> Html msg
 datePicker onChange =
     datePickerWithConfig (defaultDatePickerConfig onChange)
 
@@ -225,7 +225,7 @@ type alias Model = { datePickerState : DateTimePicker.State, value : Maybe Date 
             model.value
 
 -}
-datePickerWithConfig : Config (DatePickerConfig {}) msg -> List (Html.Attribute msg) -> State -> Maybe Date -> Html msg
+datePickerWithConfig : Config (DatePickerConfig {}) msg -> List (Html.Attribute msg) -> State -> Maybe Date.Date -> Html msg
 datePickerWithConfig config =
     view (DateType config)
 
@@ -245,7 +245,7 @@ type alias Model = { dateTimePickerState : DateTimePicker.State, value : Maybe D
             model.value
 
 -}
-dateTimePicker : (State -> Maybe Date -> msg) -> List (Html.Attribute msg) -> State -> Maybe Date -> Html msg
+dateTimePicker : (State -> Maybe Date.Date -> msg) -> List (Html.Attribute msg) -> State -> Maybe Date.Date -> Html msg
 dateTimePicker onChange =
     dateTimePickerWithConfig (defaultDateTimePickerConfig onChange)
 
@@ -265,7 +265,7 @@ type alias Model = { timePickerState : DateTimePicker.State, value : Maybe DateT
             model.value
 
 -}
-timePicker : (State -> Maybe Date -> msg) -> List (Html.Attribute msg) -> State -> Maybe Date -> Html msg
+timePicker : (State -> Maybe Date.Date -> msg) -> List (Html.Attribute msg) -> State -> Maybe Date.Date -> Html msg
 timePicker onChange =
     timePickerWithConfig (defaultTimePickerConfig onChange)
 
@@ -295,7 +295,7 @@ type alias Model = { dateTimePickerState : DateTimePicker.State, value : Maybe D
             model.value
 
 -}
-dateTimePickerWithConfig : Config (DatePickerConfig TimePickerConfig) msg -> List (Html.Attribute msg) -> State -> Maybe Date -> Html msg
+dateTimePickerWithConfig : Config (DatePickerConfig TimePickerConfig) msg -> List (Html.Attribute msg) -> State -> Maybe Date.Date -> Html msg
 dateTimePickerWithConfig config =
     view (DateTimeType config)
 
@@ -324,12 +324,12 @@ type alias Model = { timePickerState : DateTimePicker.State, value : Maybe Date 
             model.value
 
 -}
-timePickerWithConfig : Config TimePickerConfig msg -> List (Html.Attribute msg) -> State -> Maybe Date -> Html msg
+timePickerWithConfig : Config TimePickerConfig msg -> List (Html.Attribute msg) -> State -> Maybe Date.Date -> Html msg
 timePickerWithConfig config =
     view (TimeType config)
 
 
-view : Type msg -> List (Html.Attribute msg) -> State -> Maybe Date -> Html msg
+view : Type msg -> List (Html.Attribute msg) -> State -> Maybe Date.Date -> Html msg
 view pickerType attributes state currentDate =
     let
         stateValue =
@@ -378,7 +378,7 @@ view pickerType attributes state currentDate =
 -- VIEW HELPERSs
 
 
-dialog : Type msg -> State -> Maybe Date -> Html msg
+dialog : Type msg -> State -> Maybe Date.Date -> Html msg
 dialog pickerType state currentDate =
     let
         stateValue =
@@ -411,7 +411,7 @@ dialog pickerType state currentDate =
                 ]
 
 
-datePickerDialog : Type msg -> State -> Maybe Date -> Html msg
+datePickerDialog : Type msg -> State -> Maybe Date.Date -> Html msg
 datePickerDialog pickerType state currentDate =
     let
         stateValue =
@@ -438,7 +438,7 @@ datePickerDialog pickerType state currentDate =
             text ""
 
 
-navigation : DatePickerConfig (Config config msg) -> State -> Maybe Date -> List (Html msg)
+navigation : DatePickerConfig (Config config msg) -> State -> Maybe Date.Date -> List (Html msg)
 navigation config state currentDate =
     [ previousYearButton config state currentDate
     , previousButton config state currentDate
@@ -448,7 +448,7 @@ navigation config state currentDate =
     ]
 
 
-title : DatePickerConfig (Config config msg) -> State -> Maybe Date -> Html msg
+title : DatePickerConfig (Config config msg) -> State -> Maybe Date.Date -> Html msg
 title config state currentDate =
     let
         stateValue =
@@ -468,7 +468,7 @@ title config state currentDate =
         ]
 
 
-previousYearButton : DatePickerConfig (Config config msg) -> State -> Maybe Date -> Html msg
+previousYearButton : DatePickerConfig (Config config msg) -> State -> Maybe Date.Date -> Html msg
 previousYearButton config state currentDate =
     if config.allowYearNavigation then
         span
@@ -489,7 +489,7 @@ noYearNavigationClass config =
         [ NoYearNavigation ]
 
 
-previousButton : DatePickerConfig (Config config msg) -> State -> Maybe Date -> Html msg
+previousButton : DatePickerConfig (Config config msg) -> State -> Maybe Date.Date -> Html msg
 previousButton config state currentDate =
     span
         [ class <| ArrowLeft :: noYearNavigationClass config
@@ -499,7 +499,7 @@ previousButton config state currentDate =
         [ DateTimePicker.Svg.leftArrow ]
 
 
-nextButton : DatePickerConfig (Config config msg) -> State -> Maybe Date -> Html msg
+nextButton : DatePickerConfig (Config config msg) -> State -> Maybe Date.Date -> Html msg
 nextButton config state currentDate =
     span
         [ class <| ArrowRight :: noYearNavigationClass config
@@ -509,7 +509,7 @@ nextButton config state currentDate =
         [ DateTimePicker.Svg.rightArrow ]
 
 
-nextYearButton : DatePickerConfig (Config config msg) -> State -> Maybe Date -> Html msg
+nextYearButton : DatePickerConfig (Config config msg) -> State -> Maybe Date.Date -> Html msg
 nextYearButton config state currentDate =
     if config.allowYearNavigation then
         span
@@ -522,7 +522,7 @@ nextYearButton config state currentDate =
         Html.text ""
 
 
-timePickerDialog : Type msg -> State -> Maybe Date -> Html msg
+timePickerDialog : Type msg -> State -> Maybe Date.Date -> Html msg
 timePickerDialog pickerType state currentDate =
     let
         html config =
@@ -544,7 +544,7 @@ timePickerDialog pickerType state currentDate =
             html config
 
 
-digitalTimePickerDialog : Type msg -> State -> Maybe Date -> Html msg
+digitalTimePickerDialog : Type msg -> State -> Maybe Date.Date -> Html msg
 digitalTimePickerDialog pickerType state currentDate =
     let
         stateValue =
@@ -695,7 +695,7 @@ digitalTimePickerDialog pickerType state currentDate =
             html config
 
 
-analogTimePickerDialog : Type msg -> State -> Maybe Date -> Html msg
+analogTimePickerDialog : Type msg -> State -> Maybe Date.Date -> Html msg
 analogTimePickerDialog pickerType state currentDate =
     let
         stateValue =
@@ -777,7 +777,7 @@ analogTimePickerDialog pickerType state currentDate =
             html config
 
 
-calendar : Type msg -> State -> Maybe Date -> Html msg
+calendar : Type msg -> State -> Maybe Date.Date -> Html msg
 calendar pickerType state currentDate =
     let
         stateValue =
@@ -904,7 +904,7 @@ dayNames config =
 -- EVENT HANDLERS
 
 
-inputChangeHandler : Config a msg -> StateValue -> Maybe Date -> Maybe Date -> msg
+inputChangeHandler : Config a msg -> StateValue -> Maybe Date.Date -> Maybe Date.Date -> msg
 inputChangeHandler config stateValue currentDate maybeDate =
     case maybeDate of
         Just date ->
@@ -1162,7 +1162,7 @@ dateClickHandler pickerType stateValue year month day =
             handler config
 
 
-datePickerFocused : Type msg -> Config a msg -> StateValue -> Maybe Date -> msg
+datePickerFocused : Type msg -> Config a msg -> StateValue -> Maybe Date.Date -> msg
 datePickerFocused pickerType config stateValue currentDate =
     let
         updatedTitleDate =
@@ -1201,7 +1201,7 @@ datePickerFocused pickerType config stateValue currentDate =
         currentDate
 
 
-onChangeHandler : Type msg -> StateValue -> Maybe Date -> msg
+onChangeHandler : Type msg -> StateValue -> Maybe Date.Date -> msg
 onChangeHandler pickerType stateValue currentDate =
     let
         justDateHandler config =
@@ -1226,7 +1226,7 @@ onChangeHandler pickerType stateValue currentDate =
             withTimeHandler config
 
 
-hourUpHandler : Config config msg -> StateValue -> Maybe Date -> msg
+hourUpHandler : Config config msg -> StateValue -> Maybe Date.Date -> msg
 hourUpHandler config stateValue currentDate =
     let
         updatedState =
@@ -1238,7 +1238,7 @@ hourUpHandler config stateValue currentDate =
     config.onChange (InternalState updatedState) currentDate
 
 
-hourDownHandler : Config config msg -> StateValue -> Maybe Date -> msg
+hourDownHandler : Config config msg -> StateValue -> Maybe Date.Date -> msg
 hourDownHandler config stateValue currentDate =
     let
         updatedState =
@@ -1250,7 +1250,7 @@ hourDownHandler config stateValue currentDate =
     config.onChange (InternalState updatedState) currentDate
 
 
-minuteUpHandler : Config config msg -> StateValue -> Maybe Date -> msg
+minuteUpHandler : Config config msg -> StateValue -> Maybe Date.Date -> msg
 minuteUpHandler config stateValue currentDate =
     let
         updatedState =
@@ -1262,7 +1262,7 @@ minuteUpHandler config stateValue currentDate =
     config.onChange (InternalState updatedState) currentDate
 
 
-minuteDownHandler : Config config msg -> StateValue -> Maybe Date -> msg
+minuteDownHandler : Config config msg -> StateValue -> Maybe Date.Date -> msg
 minuteDownHandler config stateValue currentDate =
     let
         updatedState =
@@ -1274,7 +1274,7 @@ minuteDownHandler config stateValue currentDate =
     config.onChange (InternalState updatedState) currentDate
 
 
-timeIndicatorHandler : Config config msg -> StateValue -> Maybe Date -> DateTimePicker.Internal.TimeIndicator -> msg
+timeIndicatorHandler : Config config msg -> StateValue -> Maybe Date.Date -> DateTimePicker.Internal.TimeIndicator -> msg
 timeIndicatorHandler config stateValue currentDate timeIndicator =
     let
         updatedState =
@@ -1303,7 +1303,7 @@ timeIndicatorHandler config stateValue currentDate timeIndicator =
     config.onChange (InternalState updatedState) currentDate
 
 
-amPmIndicatorHandler : Config config msg -> StateValue -> Maybe Date -> msg
+amPmIndicatorHandler : Config config msg -> StateValue -> Maybe Date.Date -> msg
 amPmIndicatorHandler config stateValue currentDate =
     let
         updateTime time =
@@ -1326,7 +1326,7 @@ amPmIndicatorHandler config stateValue currentDate =
     config.onChange (InternalState updatedState) currentDate
 
 
-amPmPickerHandler : Type msg -> Config config msg -> StateValue -> Maybe Date -> String -> msg
+amPmPickerHandler : Type msg -> Config config msg -> StateValue -> Maybe Date.Date -> String -> msg
 amPmPickerHandler pickerType config stateValue currentDate amPm =
     let
         time =

--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -49,7 +49,7 @@ import DateTimePicker.ClockUtils
 import DateTimePicker.Config exposing (Config, DatePickerConfig, TimePickerConfig, TimePickerType(..), Type(..), defaultDatePickerConfig, defaultDateTimePickerConfig, defaultTimePickerConfig)
 import DateTimePicker.DateUtils
 import DateTimePicker.Events exposing (onBlurWithChange, onMouseDownPreventDefault, onMouseUpPreventDefault, onTouchEndPreventDefault, onTouchStartPreventDefault)
-import DateTimePicker.Helpers exposing (updateCurrentDate, updateTimeIndicator)
+import DateTimePicker.Helpers as Helpers exposing (updateCurrentDate, updateTimeIndicator)
 import DateTimePicker.Internal exposing (InternalState(..), StateValue, Time, getStateValue, initialStateValue, initialStateValueWithToday)
 import DateTimePicker.SharedStyles exposing (CssClasses(..), datepickerNamespace)
 import DateTimePicker.Svg
@@ -594,15 +594,15 @@ analogTimePickerDialog pickerType state currentDate =
                             amPmPicker config
 
                         _ ->
-                            DateTimePicker.AnalogClock.clock pickerType config.onChange state currentDate
+                            DateTimePicker.AnalogClock.clock config.onChange state currentDate
                     ]
                 ]
 
         amPmPicker config =
             div [ class [ AMPMPicker ] ]
                 [ div
-                    [ onMouseDownPreventDefault <| amPmPickerHandler pickerType config stateValue currentDate "AM"
-                    , onTouchStartPreventDefault <| amPmPickerHandler pickerType config stateValue currentDate "AM"
+                    [ onMouseDownPreventDefault <| amPmPickerHandler config stateValue currentDate "AM"
+                    , onTouchStartPreventDefault <| amPmPickerHandler config stateValue currentDate "AM"
                     , case stateValue.time.amPm of
                         Just "AM" ->
                             class [ AM, SelectedAmPm ]
@@ -612,8 +612,8 @@ analogTimePickerDialog pickerType state currentDate =
                     ]
                     [ text "AM" ]
                 , div
-                    [ onMouseDownPreventDefault <| amPmPickerHandler pickerType config stateValue currentDate "PM"
-                    , onTouchStartPreventDefault <| amPmPickerHandler pickerType config stateValue currentDate "PM"
+                    [ onMouseDownPreventDefault <| amPmPickerHandler config stateValue currentDate "PM"
+                    , onTouchStartPreventDefault <| amPmPickerHandler config stateValue currentDate "PM"
                     , case stateValue.time.amPm of
                         Just "PM" ->
                             class [ PM, SelectedAmPm ]
@@ -1003,8 +1003,8 @@ amPmIndicatorHandler config stateValue currentDate =
     config.onChange (InternalState updatedState) currentDate
 
 
-amPmPickerHandler : Type msg -> Config config msg -> StateValue -> Maybe Date.Date -> String -> msg
-amPmPickerHandler pickerType config stateValue currentDate amPm =
+amPmPickerHandler : Config config msg -> StateValue -> Maybe Date.Date -> String -> msg
+amPmPickerHandler config stateValue currentDate amPm =
     let
         time =
             stateValue.time
@@ -1018,4 +1018,4 @@ amPmPickerHandler pickerType config stateValue currentDate amPm =
     in
     config.onChange
         (InternalState updatedState)
-        (updateCurrentDate pickerType updatedState)
+        (updateCurrentDate Helpers.TimeType updatedState)

--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -15,9 +15,19 @@ module DateTimePicker
 {-| DateTime Picker
 
 
-# View
+# Picking date and time
 
-@docs datePicker, datePickerWithConfig, dateTimePicker, dateTimePickerWithConfig, timePicker, timePickerWithConfig
+@docs dateTimePicker, dateTimePickerWithConfig
+
+
+# Picking dates
+
+@docs datePicker, datePickerWithConfig
+
+
+# Picking times
+
+@docs timePicker, timePickerWithConfig
 
 
 # Initial

--- a/src/DateTimePicker/Helpers.elm
+++ b/src/DateTimePicker/Helpers.elm
@@ -1,12 +1,17 @@
-module DateTimePicker.Helpers exposing (updateCurrentDate, updateTimeIndicator)
+module DateTimePicker.Helpers exposing (Type(..), updateCurrentDate, updateTimeIndicator)
 
 import Date exposing (Date)
-import DateTimePicker.Config exposing (Type(..))
 import DateTimePicker.DateUtils
 import DateTimePicker.Internal exposing (StateValue, TimeIndicator(..))
 
 
-updateCurrentDate : Type msg -> StateValue -> Maybe Date
+type Type
+    = DateType
+    | DateTimeType
+    | TimeType
+
+
+updateCurrentDate : Type -> StateValue -> Maybe Date
 updateCurrentDate pickerType stateValue =
     let
         updatedDate =
@@ -29,13 +34,13 @@ updateCurrentDate pickerType stateValue =
                     Nothing
     in
     case pickerType of
-        DateType _ ->
+        DateType ->
             updatedDate
 
-        DateTimeType _ ->
+        DateTimeType ->
             updatedDateTime
 
-        TimeType _ ->
+        TimeType ->
             updatedTime
 
 

--- a/src/TimePickerPanel.elm
+++ b/src/TimePickerPanel.elm
@@ -1,0 +1,499 @@
+module TimePickerPanel exposing (Config, analog, digital)
+
+import Date exposing (Date)
+import DateTimePicker.AnalogClock
+import DateTimePicker.ClockUtils
+import DateTimePicker.DateUtils
+import DateTimePicker.Events exposing (onBlurWithChange, onMouseDownPreventDefault, onMouseUpPreventDefault, onTouchEndPreventDefault, onTouchStartPreventDefault)
+import DateTimePicker.Helpers exposing (Type(..), updateCurrentDate, updateTimeIndicator)
+import DateTimePicker.Internal exposing (InternalState(..), StateValue, Time, getStateValue, initialStateValue, initialStateValueWithToday)
+import DateTimePicker.SharedStyles exposing (CssClasses(..), datepickerNamespace)
+import DateTimePicker.Svg
+import Html exposing (Html, button, div, input, li, span, table, tbody, td, text, th, thead, tr, ul)
+import String
+
+
+-- MODEL
+
+
+{-| The state of the date time picker (for Internal Use)
+-}
+type alias State =
+    InternalState
+
+
+type alias Config msg =
+    { onChange : State -> Maybe Date -> msg
+    , titleFormatter : Date -> String
+    , requiresDate : Bool
+    }
+
+
+
+-- VIEWS
+
+
+{ id, class, classList } =
+    datepickerNamespace
+
+
+digital : Config msg -> State -> Maybe Date.Date -> Html msg
+digital config state currentDate =
+    let
+        stateValue =
+            getStateValue state
+
+        toListItem str =
+            li [] [ text str ]
+
+        hours =
+            List.range stateValue.hourPickerStart (stateValue.hourPickerStart + 6)
+
+        minutes =
+            List.range stateValue.minutePickerStart (stateValue.minutePickerStart + 6)
+
+        ampmList =
+            [ "AM", "PM" ]
+
+        timeSelector =
+            List.map3 toRow hours minutes (ampmList ++ List.repeat 4 "")
+
+        toRow hour min ampm =
+            tr []
+                [ hourCell hour
+                , minuteCell min
+                , amPmCell ampm
+                ]
+
+        hourCell hour =
+            td
+                [ onMouseDownPreventDefault <| hourClickHandler config stateValue hour
+                , onTouchStartPreventDefault <| hourClickHandler config stateValue hour
+                , stateValue.time.hour
+                    |> Maybe.map ((==) hour)
+                    |> Maybe.map
+                        (\selected ->
+                            if selected then
+                                class [ SelectedHour ]
+                            else
+                                class []
+                        )
+                    |> Maybe.withDefault (class [])
+                ]
+                [ text <| (toString >> DateTimePicker.DateUtils.padding) hour ]
+
+        minuteCell min =
+            td
+                [ onMouseDownPreventDefault <| minuteClickHandler config stateValue min
+                , onTouchStartPreventDefault <| minuteClickHandler config stateValue min
+                , stateValue.time.minute
+                    |> Maybe.map ((==) min)
+                    |> Maybe.map
+                        (\selected ->
+                            if selected then
+                                class [ SelectedMinute ]
+                            else
+                                class []
+                        )
+                    |> Maybe.withDefault (class [])
+                ]
+                [ text <| (toString >> DateTimePicker.DateUtils.padding) min ]
+
+        amPmCell ampm =
+            let
+                defaultClasses =
+                    class <|
+                        if ampm == "" then
+                            [ EmptyCell ]
+                        else
+                            []
+            in
+            td
+                ([ stateValue.time.amPm
+                    |> Maybe.map ((==) ampm)
+                    |> Maybe.map
+                        (\selected ->
+                            if selected then
+                                class [ SelectedAmPm ]
+                            else
+                                defaultClasses
+                        )
+                    |> Maybe.withDefault defaultClasses
+                 ]
+                    ++ (if ampm == "" then
+                            []
+                        else
+                            [ onMouseDownPreventDefault <| amPmClickHandler config stateValue ampm
+                            , onTouchStartPreventDefault <| amPmClickHandler config stateValue ampm
+                            ]
+                       )
+                )
+                [ text ampm ]
+
+        upArrows config =
+            [ tr [ class [ ArrowUp ] ]
+                [ td
+                    [ onMouseDownPreventDefault <| hourUpHandler config stateValue currentDate
+                    , onTouchStartPreventDefault <| hourUpHandler config stateValue currentDate
+                    ]
+                    [ DateTimePicker.Svg.upArrow ]
+                , td
+                    [ onMouseDownPreventDefault <| minuteUpHandler config stateValue currentDate
+                    , onTouchStartPreventDefault <| minuteUpHandler config stateValue currentDate
+                    ]
+                    [ DateTimePicker.Svg.upArrow ]
+                , td [] []
+                ]
+            ]
+
+        downArrows config =
+            [ tr [ class [ ArrowDown ] ]
+                [ td
+                    [ onMouseDownPreventDefault <| hourDownHandler config stateValue currentDate
+                    , onTouchStartPreventDefault <| hourDownHandler config stateValue currentDate
+                    ]
+                    [ DateTimePicker.Svg.downArrow ]
+                , td
+                    [ onMouseDownPreventDefault <| minuteDownHandler config stateValue currentDate
+                    , onTouchStartPreventDefault <| minuteDownHandler config stateValue currentDate
+                    ]
+                    [ DateTimePicker.Svg.downArrow ]
+                , td [] []
+                ]
+            ]
+    in
+    div [ class [ TimePickerDialog, DigitalTime ] ]
+        [ div [ class [ Header ] ]
+            [ Maybe.map config.titleFormatter currentDate |> Maybe.withDefault "-- : --" |> text ]
+        , div [ class [ Body ] ]
+            [ table []
+                [ tbody []
+                    (upArrows config
+                        ++ timeSelector
+                        ++ downArrows config
+                    )
+                ]
+            ]
+        ]
+
+
+analog : Config msg -> State -> Maybe Date.Date -> Html msg
+analog config state currentDate =
+    let
+        stateValue =
+            getStateValue state
+
+        isActive timeIndicator =
+            if stateValue.activeTimeIndicator == Just timeIndicator then
+                [ Active ]
+            else
+                []
+
+        amPmPicker config =
+            div [ class [ AMPMPicker ] ]
+                [ div
+                    [ onMouseDownPreventDefault <| amPmPickerHandler config stateValue currentDate "AM"
+                    , onTouchStartPreventDefault <| amPmPickerHandler config stateValue currentDate "AM"
+                    , case stateValue.time.amPm of
+                        Just "AM" ->
+                            class [ AM, SelectedAmPm ]
+
+                        _ ->
+                            class [ AM ]
+                    ]
+                    [ text "AM" ]
+                , div
+                    [ onMouseDownPreventDefault <| amPmPickerHandler config stateValue currentDate "PM"
+                    , onTouchStartPreventDefault <| amPmPickerHandler config stateValue currentDate "PM"
+                    , case stateValue.time.amPm of
+                        Just "PM" ->
+                            class [ PM, SelectedAmPm ]
+
+                        _ ->
+                            class [ PM ]
+                    ]
+                    [ text "PM" ]
+                ]
+    in
+    div [ class [ TimePickerDialog, AnalogTime ] ]
+        [ div [ class [ Header ] ]
+            [ span
+                [ onMouseDownPreventDefault (timeIndicatorHandler config stateValue currentDate DateTimePicker.Internal.HourIndicator)
+                , onTouchStartPreventDefault (timeIndicatorHandler config stateValue currentDate DateTimePicker.Internal.HourIndicator)
+                , class (Hour :: isActive DateTimePicker.Internal.HourIndicator)
+                ]
+                [ text (stateValue.time.hour |> Maybe.map (toString >> DateTimePicker.DateUtils.padding) |> Maybe.withDefault "--") ]
+            , span [ class [ Separator ] ] [ text " : " ]
+            , span
+                [ onMouseDownPreventDefault (timeIndicatorHandler config stateValue currentDate DateTimePicker.Internal.MinuteIndicator)
+                , onTouchStartPreventDefault (timeIndicatorHandler config stateValue currentDate DateTimePicker.Internal.MinuteIndicator)
+                , class (Minute :: isActive DateTimePicker.Internal.MinuteIndicator)
+                ]
+                [ text (stateValue.time.minute |> Maybe.map (toString >> DateTimePicker.DateUtils.padding) |> Maybe.withDefault "--") ]
+            , span
+                [ onMouseDownPreventDefault (timeIndicatorHandler config stateValue currentDate DateTimePicker.Internal.AMPMIndicator)
+                , onTouchStartPreventDefault (timeIndicatorHandler config stateValue currentDate DateTimePicker.Internal.AMPMIndicator)
+                , class (AMPM :: isActive DateTimePicker.Internal.AMPMIndicator)
+                ]
+                [ text (stateValue.time.amPm |> Maybe.withDefault "--") ]
+            ]
+        , div [ class [ Body ] ]
+            [ case stateValue.activeTimeIndicator of
+                Just DateTimePicker.Internal.AMPMIndicator ->
+                    amPmPicker config
+
+                _ ->
+                    DateTimePicker.AnalogClock.clock config.onChange state currentDate
+            ]
+        ]
+
+
+hourClickHandler : Config msg -> StateValue -> Int -> msg
+hourClickHandler config stateValue hour =
+    let
+        time =
+            stateValue.time
+
+        updatedStateValue =
+            { stateValue | time = { time | hour = Just hour }, event = "hourClickHandler" }
+
+        ( updatedDate, forceCloseWithDate ) =
+            case ( stateValue.time.minute, stateValue.time.amPm, stateValue.date ) of
+                ( Just minute, Just amPm, Just date ) ->
+                    ( Just <| DateTimePicker.DateUtils.setTime date hour minute amPm
+                    , True
+                    )
+
+                _ ->
+                    ( Nothing, False )
+
+        ( updatedTime, forceCloseTimeOnly ) =
+            case ( updatedStateValue.time.minute, updatedStateValue.time.amPm ) of
+                ( Just minute, Just amPm ) ->
+                    ( Just <| DateTimePicker.DateUtils.toTime hour minute amPm
+                    , True
+                    )
+
+                _ ->
+                    ( Nothing, False )
+
+        withDateHandler config =
+            config.onChange (InternalState { updatedStateValue | forceClose = forceCloseWithDate }) updatedDate
+
+        justTimeHandler config =
+            config.onChange (InternalState { updatedStateValue | forceClose = forceCloseTimeOnly }) updatedTime
+    in
+    if config.requiresDate then
+        withDateHandler config
+    else
+        justTimeHandler config
+
+
+minuteClickHandler : Config msg -> StateValue -> Int -> msg
+minuteClickHandler config stateValue minute =
+    let
+        time =
+            stateValue.time
+
+        updatedStateValue =
+            { stateValue | time = { time | minute = Just minute }, event = "minuteClickHandler" }
+
+        ( updatedDate, forceCloseWithDate ) =
+            case ( stateValue.time.hour, stateValue.time.amPm, stateValue.date ) of
+                ( Just hour, Just amPm, Just date ) ->
+                    ( Just <| DateTimePicker.DateUtils.setTime date hour minute amPm
+                    , True
+                    )
+
+                _ ->
+                    ( Nothing, False )
+
+        ( updatedTime, forceCloseTimeOnly ) =
+            case ( updatedStateValue.time.hour, updatedStateValue.time.amPm ) of
+                ( Just hour, Just amPm ) ->
+                    ( Just <| DateTimePicker.DateUtils.toTime hour minute amPm
+                    , True
+                    )
+
+                _ ->
+                    ( Nothing, False )
+
+        withDateHandler config =
+            config.onChange (InternalState { updatedStateValue | forceClose = forceCloseWithDate }) updatedDate
+
+        justTimeHandler config =
+            config.onChange (InternalState { updatedStateValue | forceClose = forceCloseTimeOnly }) updatedTime
+    in
+    if config.requiresDate then
+        withDateHandler config
+    else
+        justTimeHandler config
+
+
+amPmClickHandler : Config msg -> StateValue -> String -> msg
+amPmClickHandler config stateValue amPm =
+    let
+        time =
+            stateValue.time
+
+        updatedStateValue =
+            { stateValue
+                | time =
+                    { time
+                        | amPm =
+                            if String.isEmpty amPm then
+                                Nothing
+                            else
+                                Just amPm
+                    }
+                , event = "amPmClickHandler"
+            }
+
+        ( updatedDate, forceCloseWithDate ) =
+            case ( stateValue.time.hour, stateValue.time.minute, stateValue.date ) of
+                ( Just hour, Just minute, Just date ) ->
+                    ( Just <| DateTimePicker.DateUtils.setTime date hour minute amPm
+                    , True
+                    )
+
+                _ ->
+                    ( Nothing, False )
+
+        ( updatedTime, forceCloseTimeOnly ) =
+            case ( updatedStateValue.time.hour, updatedStateValue.time.minute ) of
+                ( Just hour, Just minute ) ->
+                    ( Just <| DateTimePicker.DateUtils.toTime hour minute amPm
+                    , True
+                    )
+
+                _ ->
+                    ( Nothing, False )
+
+        withDateHandler config =
+            config.onChange (InternalState { updatedStateValue | forceClose = forceCloseWithDate }) updatedDate
+
+        justTimeHandler config =
+            config.onChange (InternalState { updatedStateValue | forceClose = forceCloseTimeOnly }) updatedTime
+    in
+    if config.requiresDate then
+        withDateHandler config
+    else
+        justTimeHandler config
+
+
+hourUpHandler : Config msg -> StateValue -> Maybe Date.Date -> msg
+hourUpHandler config stateValue currentDate =
+    let
+        updatedState =
+            if stateValue.hourPickerStart - 6 >= 1 then
+                { stateValue | hourPickerStart = stateValue.hourPickerStart - 6 }
+            else
+                stateValue
+    in
+    config.onChange (InternalState updatedState) currentDate
+
+
+hourDownHandler : Config msg -> StateValue -> Maybe Date.Date -> msg
+hourDownHandler config stateValue currentDate =
+    let
+        updatedState =
+            if stateValue.hourPickerStart + 6 <= 12 then
+                { stateValue | hourPickerStart = stateValue.hourPickerStart + 6 }
+            else
+                stateValue
+    in
+    config.onChange (InternalState updatedState) currentDate
+
+
+minuteUpHandler : Config msg -> StateValue -> Maybe Date.Date -> msg
+minuteUpHandler config stateValue currentDate =
+    let
+        updatedState =
+            if stateValue.minutePickerStart - 6 >= 0 then
+                { stateValue | minutePickerStart = stateValue.minutePickerStart - 6 }
+            else
+                stateValue
+    in
+    config.onChange (InternalState updatedState) currentDate
+
+
+minuteDownHandler : Config msg -> StateValue -> Maybe Date.Date -> msg
+minuteDownHandler config stateValue currentDate =
+    let
+        updatedState =
+            if stateValue.minutePickerStart + 6 <= 59 then
+                { stateValue | minutePickerStart = stateValue.minutePickerStart + 6 }
+            else
+                stateValue
+    in
+    config.onChange (InternalState updatedState) currentDate
+
+
+timeIndicatorHandler : Config msg -> StateValue -> Maybe Date.Date -> DateTimePicker.Internal.TimeIndicator -> msg
+timeIndicatorHandler config stateValue currentDate timeIndicator =
+    let
+        updatedState =
+            { stateValue
+                | activeTimeIndicator = updatedActiveTimeIndicator
+                , currentAngle = currentAngle
+            }
+
+        updatedActiveTimeIndicator =
+            if stateValue.activeTimeIndicator == Just timeIndicator then
+                Nothing
+            else
+                Just timeIndicator
+
+        currentAngle =
+            case ( timeIndicator, stateValue.time.hour, stateValue.time.minute ) of
+                ( DateTimePicker.Internal.HourIndicator, Just hour, _ ) ->
+                    DateTimePicker.ClockUtils.hourToAngle hour
+
+                ( DateTimePicker.Internal.MinuteIndicator, _, Just minute ) ->
+                    DateTimePicker.ClockUtils.minuteToAngle minute
+
+                ( _, _, _ ) ->
+                    Nothing
+    in
+    config.onChange (InternalState updatedState) currentDate
+
+
+amPmIndicatorHandler : Config msg -> StateValue -> Maybe Date.Date -> msg
+amPmIndicatorHandler config stateValue currentDate =
+    let
+        updateTime time =
+            case time.amPm of
+                Just "AM" ->
+                    { time | amPm = Just "PM" }
+
+                Just "PM" ->
+                    { time | amPm = Just "AM" }
+
+                _ ->
+                    { time | amPm = Just "AM" }
+
+        updatedState =
+            { stateValue
+                | activeTimeIndicator = Just DateTimePicker.Internal.AMPMIndicator
+                , time = updateTime stateValue.time
+            }
+    in
+    config.onChange (InternalState updatedState) currentDate
+
+
+amPmPickerHandler : Config msg -> StateValue -> Maybe Date.Date -> String -> msg
+amPmPickerHandler config stateValue currentDate amPm =
+    let
+        time =
+            stateValue.time
+
+        updatedTime =
+            { time | amPm = Just amPm }
+
+        updatedState =
+            { stateValue | time = updatedTime }
+                |> updateTimeIndicator
+    in
+    config.onChange
+        (InternalState updatedState)
+        (updateCurrentDate TimeType updatedState)


### PR DESCRIPTION
Refactoring to prep for #27.

This PR only refactors and does not change the UI or API.  This splits out the date and time picker views to simplify DateTimePicker.elm, and untangles those views from depending on the user-facing config types.