### PR TITLE
Fix syntax error in init example in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ type alias Model =
     }
 
 init = 
-    ( { selectedDate = Nothing, datePickerState.initialState }
+    ( { selectedDate = Nothing, datePickerState = DateTimePicker.initialState }
     , DateTimePicker.initialCmd DateChange DateTimePicker.initialState
     )
 


### PR DESCRIPTION
There was a small error in the init example in the README. This PR replaces the erroneous code with the  code from demo/RandomDemo.elm.