### PR TITLE
Updated the list-extra module version

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,7 @@
     ],
     "dependencies": {
         "abadi199/dateparser": "1.0.0 <= v < 2.0.0",
-        "elm-community/list-extra": "4.0.0 <= v < 7.0.0",
+        "elm-community/list-extra": "4.0.0 <= v < 8.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,7 +9,7 @@
     "abadi199/dateparser": "1.0.0 <= v < 2.0.0",
     "eeue56/elm-html-test": "5.0.1 <= v < 6.0.0",
     "elm-community/elm-test": "4.1.1 <= v < 5.0.0",
-    "elm-community/list-extra": "4.0.0 <= v < 7.0.0",
+    "elm-community/list-extra": "4.0.0 <= v < 8.0.0",
     "elm-lang/core": "5.0.0 <= v < 6.0.0",
     "elm-lang/html": "2.0.0 <= v < 3.0.0",
     "elm-lang/svg": "2.0.0 <= v < 3.0.0",


### PR DESCRIPTION
We are using the datetimepicker module which is great, so thank you for creating it! However we are using the latest list-extra module, but elm-package will go down to the version that is installed in datetimepicker as it's a dependency. Would it be possible to upgrade to the latest version. We ran the tests and they ran fine.

It might be worth updating to the latest version of elm-date-extra too as it may cause the same issue.

Thank you.